### PR TITLE
Compiler warnings for two tr functions: "no return statement in funct…

### DIFF
--- a/FieldOpt/Optimization/optimizers/trust_region/TrustRegionModel.cpp
+++ b/FieldOpt/Optimization/optimizers/trust_region/TrustRegionModel.cpp
@@ -272,6 +272,7 @@ double TrustRegionModel::checkInterpolation() {
       }
     }
   }
+  return max_diff;
 }
 
 void TrustRegionModel::submitTempInitCases() {

--- a/FieldOpt/Optimization/optimizers/trust_region/TrustRegionOptimization.cpp
+++ b/FieldOpt/Optimization/optimizers/trust_region/TrustRegionOptimization.cpp
@@ -595,6 +595,7 @@ bool TrustRegionOptimization::ensureImprovementPostProcessing(){
     updateRadius();
     return false;
   }
+  return false;
 }
 
 Optimization::Optimizer::TerminationCondition


### PR DESCRIPTION
…ion returning non-void".

These two tr functions don't have return statements. Do these additions make sense?