### PR TITLE
Add inertia weight parameter for PSO optimizer

### DIFF
--- a/FieldOpt/Optimization/optimizers/PSO.cpp
+++ b/FieldOpt/Optimization/optimizers/PSO.cpp
@@ -46,6 +46,10 @@ PSO::PSO(Settings::Optimizer *settings,
   stagnation_limit_ = settings->parameters().stagnation_limit;
   learning_factor_1_ = settings->parameters().pso_learning_factor_1;
   learning_factor_2_ = settings->parameters().pso_learning_factor_2;
+  inertia_weight_ = settings->parameters().pso_inertia_weight;
+  inertia_weight_max_ = settings->parameters().pso_inertia_weight_max;
+  inertia_weight_min_ = settings->parameters().pso_inertia_weight_min;
+  inertia_decay_ = settings->parameters().pso_inertia_decay;
   number_of_particles_ = settings->parameters().pso_swarm_size;
 
   if (constraint_handler_ != nullptr) { // All actual cases
@@ -213,13 +217,15 @@ PSO::Particle PSO::find_best_in_particle_memory(int particle_num){
 
 vector<PSO::Particle> PSO::update_velocity() {
   vector<Particle> new_swarm;
+  double inertia_multiple = inertia_decay_ ?
+                      inertia_weight_max_ - ((iteration_*1.0/max_iterations_) * (inertia_weight_max_-inertia_weight_min_)) : inertia_weight_;
   for(int i = 0; i < swarm_.size(); i++){
     Particle best_in_particle_memory = find_best_in_particle_memory(i);
     new_swarm.push_back(swarm_[i]);
     for(int j = 0; j < n_vars_; j++){
       double velocity_1 = learning_factor_1_ * random_double(gen_, 0, 1) * (best_in_particle_memory.rea_vars(j)-swarm_[i].rea_vars(j));
       double velocity_2 = learning_factor_2_ * random_double(gen_, 0, 1) * (current_best_particle_global_.rea_vars(j)-swarm_[i].rea_vars(j));
-      new_swarm[i].rea_vars_velocity(j) = swarm_[i].rea_vars_velocity(j) + velocity_1 + velocity_2;
+      new_swarm[i].rea_vars_velocity(j) = (inertia_multiple * swarm_[i].rea_vars_velocity(j)) + velocity_1 + velocity_2;
       if (new_swarm[i].rea_vars_velocity(j) < -v_max_(j)){
         new_swarm[i].rea_vars_velocity(j) = -v_max_(j);
       }else if(new_swarm[i].rea_vars_velocity(j) > v_max_(j)){

--- a/FieldOpt/Optimization/optimizers/PSO.h
+++ b/FieldOpt/Optimization/optimizers/PSO.h
@@ -124,6 +124,10 @@ class PSO : public Optimizer {
   int number_of_particles_; //!< The number of particles in the swarm
   double learning_factor_1_; //!< Learning factor 1 (c1)
   double learning_factor_2_; //!< Learning factor 2 (c2)
+  double inertia_weight_; //!< Inertia weight
+  double inertia_weight_max_; //!< Inertia weight maximum
+  double inertia_weight_min_; //!< Inertia weight minimum
+  bool inertia_decay_; //!< Use inertia weight decay if true
   Eigen::VectorXd v_max_; //!< Max velocity of the particle
   int max_iterations_; //!< Max iterations
   vector<Particle> swarm_; //!< Current swarm of particles

--- a/FieldOpt/Optimization/tests/optimizers/test_pso.cpp
+++ b/FieldOpt/Optimization/tests/optimizers/test_pso.cpp
@@ -92,4 +92,21 @@ TEST_F(PSOTest, TestFunctionRosenbrock) {
   EXPECT_NEAR(1.0, best_case->GetRealVarVector()[1], 0.5);
 }
 
+TEST_F(PSOTest, TestFunctionDecayRosenbrock) {
+  test_case_ga_spherical_6r_->set_objf_value(abs(Rosenbrock(test_case_ga_spherical_6r_->GetRealVarVector())));
+  settings_pso_decay_min_->SetRngSeed(5);
+  Optimization::Optimizer *minimizer = new PSO(settings_pso_decay_min_, test_case_ga_spherical_6r_, varcont_6r_, grid_5spot_, logger_ );
+
+  while (!minimizer->IsFinished()) {
+    auto next_case = minimizer->GetCaseForEvaluation();
+    next_case->set_objf_value(Rosenbrock(next_case->GetRealVarVector()));
+    minimizer->SubmitEvaluatedCase(next_case);
+  }
+  auto best_case = minimizer->GetTentativeBestCase();
+
+  EXPECT_NEAR(0.0, best_case->objf_value(), 1);
+  EXPECT_NEAR(1.0, best_case->GetRealVarVector()[0], 0.5);
+  EXPECT_NEAR(1.0, best_case->GetRealVarVector()[1], 0.5);
+}
+
 }

--- a/FieldOpt/Optimization/tests/test_resource_optimizer.h
+++ b/FieldOpt/Optimization/tests/test_resource_optimizer.h
@@ -89,6 +89,10 @@ class TestResourceOptimizer :
       new Settings::Optimizer(
         get_json_settings_pso_minimize_, vp_);
 
+    settings_pso_decay_min_ =
+      new Settings::Optimizer(
+        get_json_settings_pso_decay_minimize_, vp_);
+
     settings_vfsa_min_ =
       new Settings::Optimizer(
         get_json_settings_vfsa_minimize_, vp_);
@@ -126,6 +130,7 @@ class TestResourceOptimizer :
   Settings::Optimizer *settings_spsa_min_;
   Settings::Optimizer *settings_spsa_max_;
   Settings::Optimizer *settings_pso_min_;
+  Settings::Optimizer *settings_pso_decay_min_;
   Settings::Optimizer *settings_ego_max_;
   Settings::Optimizer *settings_cma_es_min_;
   Settings::Optimizer *settings_tr_opt_max_;
@@ -309,6 +314,25 @@ class TestResourceOptimizer :
       {"PSO-SwarmSize",          10},
       {"PSO-LearningFactor1",    2.2},
       {"PSO-LearningFactor2",    1.8},
+      {"PSO-InertiaWeight",      1.0},
+      {"PSO-VelocityScale",      0.025},
+      {"LowerBound",            -5.0},
+      {"UpperBound",             5.0}
+    }},
+    {"Objective", obj_fun_}
+  };
+
+  QJsonObject get_json_settings_pso_decay_minimize_{
+    {"Type", "PSO"},
+    {"Mode", "Minimize"},
+    {"Parameters", QJsonObject{
+      {"MaxGenerations",        700},
+      {"PSO-SwarmSize",          10},
+      {"PSO-LearningFactor1",    2.2},
+      {"PSO-LearningFactor2",    1.8},
+      {"PSO-InertiaWeightMax",   1.1},
+      {"PSO-InertiaWeightMin",   0.9},
+      {"PSO-InertiaDecay",       true},
       {"PSO-VelocityScale",      0.025},
       {"LowerBound",            -5.0},
       {"UpperBound",             5.0}

--- a/FieldOpt/Settings/optimizer.cpp
+++ b/FieldOpt/Settings/optimizer.cpp
@@ -502,12 +502,32 @@ Optimizer::Parameters Optimizer::parseParameters(QJsonObject &json_params) {
     // PSO parameters :: PSO-LearningFactor1
     if(json_params.contains("PSO-LearningFactor1")){
       params.pso_learning_factor_1 = json_params["PSO-LearningFactor1"].toDouble();
-    } else { params.pso_learning_factor_1 = 2; }
+    } else { params.pso_learning_factor_1 = 1.5; }
 
     // PSO parameters :: PSO-LearningFactor2
     if(json_params.contains("PSO-LearningFactor2")){
       params.pso_learning_factor_2 = json_params["PSO-LearningFactor2"].toDouble();
-    } else { params.pso_learning_factor_2 = 2; }
+    } else { params.pso_learning_factor_2 = 1.5; }
+
+    // PSO parameters :: PSO-InertiaWeight
+    if(json_params.contains("PSO-InertiaWeight")){
+      params.pso_inertia_weight = json_params["PSO-InertiaWeight"].toDouble();
+    } else { params.pso_inertia_weight = 0.73; }
+
+    // PSO parameters :: PSO-InertiaWeightMax
+    if(json_params.contains("PSO-InertiaWeightMax")){
+      params.pso_inertia_weight_max = json_params["PSO-InertiaWeightMax"].toDouble();
+    } else { params.pso_inertia_weight_max = 0.9; }
+
+    // PSO parameters :: PSO-InertiaWeightMin
+    if(json_params.contains("PSO-InertiaWeightMin")){
+      params.pso_inertia_weight_min = json_params["PSO-InertiaWeightMin"].toDouble();
+    } else { params.pso_inertia_weight_min = 0.5; }
+
+    // PSO parameters :: PSO-InertiaDecay
+    if(json_params.contains("PSO-InertiaDecay")){
+      params.pso_inertia_decay = json_params["PSO-InertiaDecay"].toBool();
+    }
 
     // PSO parameters :: PSO-SwarmSize
     if(json_params.contains("PSO-SwarmSize")){

--- a/FieldOpt/Settings/optimizer.h
+++ b/FieldOpt/Settings/optimizer.h
@@ -149,12 +149,24 @@ class Optimizer
 
     // PSO parameters --------------------------------------
     //!< Learning factor (c1), from the swarms
-    //!< best known perturbation. Default: 2
+    //!< best known perturbation. Default: 1.5
     double pso_learning_factor_1;
 
     //!< Learning factor (c2), from the individual
-    //!< particle's best known perturbation. Default: 2
+    //!< particle's best known perturbation. Default: 1.5
     double pso_learning_factor_2;
+
+    //!< Particle inertia weight. Default: 0.73
+    double pso_inertia_weight;
+
+    //!< Particle maximum inertia weight. Default: 0.9
+    double pso_inertia_weight_max;
+
+    //!< Particle minimum inertia weight. Default: 0.5
+    double pso_inertia_weight_min;
+
+    //!< Particle inertia decay. Default: false
+    bool pso_inertia_decay = false;
 
     //!< # of particles in the swarm. Default: 50
     double pso_swarm_size;

--- a/examples/Flow/wellCtrOpt2w/fo_driver.CntrlOpt.PSO.json
+++ b/examples/Flow/wellCtrOpt2w/fo_driver.CntrlOpt.PSO.json
@@ -216,8 +216,9 @@
         },
         "Parameters": {
             "MaxGenerations": 30,
-            "PSO-LearningFactor1": 2,
-            "PSO-LearningFactor2": 2,
+            "PSO-LearningFactor1": 1.5,
+            "PSO-LearningFactor2": 1.5,
+            "PSO-InertiaWeight": 0.73,
             "PSO-SwarmSize": 24,
             "PSO-VelocityScale": 0.25
         },


### PR DESCRIPTION
Added inertia weight parameter for PSO optimizer. This parameter can have fixed value for a run or can decay with iterations. Learning factors 1 and 2 have been changed accordingly.

Parameter would give users more control over the optimization run behavior. This is similar to commit made on FieldOpt repo.

Reference: Inertia weight control strategies for particle swarm optimization ( https://www.researchgate.net/publication/309658844_Inertia_weight_control_strategies_for_particle_swarm_optimization_Too_much_momentum_not_enough_analysis )